### PR TITLE
Add NPM module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
+[![Gem Version](https://badge.fury.io/rb/active_admin_filters_visibility.svg)](https://badge.fury.io/rb/active_admin_filters_visibility)
+[![NPM Version](https://badge.fury.io/js/@activeadmin-plugins%2Factive_admin_filters_visibility.svg)](https://badge.fury.io/js/@activeadmin-plugins%2Factive_admin_filters_visibility)
+![npm](https://img.shields.io/npm/dm/@activeadmin-plugins/active_admin_filters_visibility)
+
 # ActiveAdminFiltersVisibility
 
 ActiveAdmin plugin allows to hide any filter from Filters Sidebar.
 Useful when page has many filters, but admin user needs only some of them.
-Every filter saves its state using browser's LocalStorage. 
+Every filter saves its state using browser's LocalStorage.
 
 ![Demonstration](https://raw.githubusercontent.com/activeadmin-plugins/active_admin_filters_visibility/master/screen/example_aa_filters_visibility.gif "Visibility example")
 
@@ -15,23 +19,51 @@ Also you can use drag&drop to change filters order
 In Gemfile add
 
 ```ruby
-  gem 'active_admin_filters_visibility', git: 'https://github.com/activeadmin-plugins/active_admin_filters_visibility' 
+  gem 'active_admin_filters_visibility', git: 'https://github.com/activeadmin-plugins/active_admin_filters_visibility'
 ```
 
-in the 
-``` 
+##### Using assets via Sprockets
+in the
+```
   app/assets/javascript/active_admin.coffee
 ```
 
-and 
+and
 
 ```coffeescript
   #= require active_admin_filters_visibility
 ```
 
-and initialize it with:
+##### Using assets via Webpacker (or any other assets bundler) as a NPM module (Yarn package)
 
-```javascript 
+Execute:
+
+    $ npm i @activeadmin-plugins/active_admin_filters_visibility
+
+Or
+
+    $ yarn add @activeadmin-plugins/active_admin_filters_visibility
+
+Or add manually to `package.json`:
+
+```json
+"dependencies": {
+  "@activeadmin-plugins/active_admin_filters_visibility": "1.2.0"
+}
+```
+and execute:
+
+    $ yarn
+
+Add the following line into `app/assets/javascripts/active_admin.js`:
+
+```javascript
+import '@activeadmin-plugins/active_admin_filters_visibility';
+```
+
+##### Initialization:
+
+```javascript
   $(document).ready(function() {
     $('#filters_sidebar_section').activeAdminFiltersVisibility();
   });
@@ -43,7 +75,7 @@ and initialize it with:
   $('.jquery-selector').activeAdminFiltersVisibility(options)
 ```
 
-ActiveAdminFiltersVisibility is a standard jQuery Plugin, and accepts some "options" as a hash. 
+ActiveAdminFiltersVisibility is a standard jQuery Plugin, and accepts some "options" as a hash.
 Default is:
 
 ```javascript
@@ -65,8 +97,8 @@ Default is:
 You can change icon - this is a HTML text or symbol. You can pass empty string and customize it with your CSS.
 Or you can set class("iconClass") for icon or inline styles("iconStyle").
 
-This plugin has minimal CSS styling. 
-In case you want to use custom CSS, default styling can be ignored: 
+This plugin has minimal CSS styling.
+In case you want to use custom CSS, default styling can be ignored:
 set ```skipDefaultCss``` to ```true```
 
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@activeadmin-plugins/active_admin_filters_visibility",
+  "version": "1.2.0",
+  "description": "Extension for activeadmin gem to hide any filters from sidebar-filters panel",
+  "main": "src/active_admin_filters_visibility.js",
+  "repository": "git@github.com:activeadmin-plugins/active_admin_filters_visibility.git",
+  "author": "Gena M. <workgena@gmail.com>",
+  "license": "MIT",
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/activeadmin-plugins/active_admin_filters_visibility.git"
+  },
+  "bugs": {
+    "url": "https://github.com/activeadmin-plugins/active_admin_filters_visibility/issues"
+  },
+  "homepage": "https://github.com/activeadmin-plugins/active_admin_filters_visibility#readme",
+  "keywords": [
+    "active",
+    "admin",
+    "filters",
+    "visibility"
+  ],
+  "files": [
+    "src/**/*"
+  ],
+  "scripts": {
+    "prepublishOnly": "rm -rf src && cp -R app/assets/javascripts/ src"
+  }
+}


### PR DESCRIPTION
This PR adds support to use this repo as an NPM/Yarn package so we can use it with Webpacker or any other assets bundler.
I implemented this so it uses the same source files as the Rails gem so any change in the JS is available in both cases. I didn't change the Rails gem-related code this same repo can be used in both ways.

After pack&publish NPM module has minimum files and should look like:
![npm_package](https://user-images.githubusercontent.com/22831505/170225060-d0e5e00e-7a68-4f1e-9ef1-a05edd55bcf1.png)